### PR TITLE
Add doctor registration link on login

### DIFF
--- a/application/views/auth/login.php
+++ b/application/views/auth/login.php
@@ -165,6 +165,9 @@
         <p class="mb-0 text-center">
           <a data-toggle="modal" href="#myModal"><?php echo lang('forgot_your_password') ?>?</a>
         </p>
+        <p class="mb-0 text-center mt-2">
+          <a href="doctor/addNewView"><?php echo lang('doctor_registration_form'); ?></a>
+        </p>
       </div>
       <!-- /.login-card-body -->
     </div>


### PR DESCRIPTION
## Summary
- link to doctor registration from the login page

## Testing
- `php -l application/views/auth/login.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c61cf0ddc832bbd2999c5ba9c0d66