### PR TITLE
Add doctor registration option

### DIFF
--- a/application/language/english/system_syntax_lang.php
+++ b/application/language/english/system_syntax_lang.php
@@ -1677,6 +1677,7 @@ $lang['emergency_contact_name'] = 'Emergency Contact Name';
 $lang['emergency_contact_number'] = 'Emergency Contact Number';
 $lang['profile_photo'] = 'Profile Photo';
 $lang['register_patient'] = 'Register Patient';
+$lang['register_doctor'] = 'Register Doctor';
 
 $lang['new_appointment'] = 'New Appointment';
 $lang['appointment_booking_form'] = 'Appointment Booking Form';

--- a/application/language/spanish/system_syntax_lang.php
+++ b/application/language/spanish/system_syntax_lang.php
@@ -1806,6 +1806,7 @@ $lang['emergency_contact_name'] = 'Nombre de Contacto de Emergencia';
 $lang['emergency_contact_number'] = 'Número de Contacto de Emergencia';
 $lang['profile_photo'] = 'Foto de Perfil';
 $lang['register_patient'] = 'Registrar Paciente';
+$lang['register_doctor'] = 'Registrar Doctor';
 
 $lang['new_appointment'] = 'Nueva Cita';
 $lang['appointment_booking_form'] = 'Formulario de Reserva de Cita';

--- a/application/views/auth/login.php
+++ b/application/views/auth/login.php
@@ -165,6 +165,9 @@
         <p class="mb-0 text-center">
           <a data-toggle="modal" href="#myModal"><?php echo lang('forgot_your_password') ?>?</a>
         </p>
+        <p class="mb-0 text-center">
+          <a href="<?php echo base_url('doctor/addNewView'); ?>"><?php echo lang('register_doctor'); ?></a>
+        </p>
       </div>
       <!-- /.login-card-body -->
     </div>


### PR DESCRIPTION
## Summary
- add Doctor Register translation string to English and Spanish
- show a "Register Doctor" link on the login page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c6fa86e3c832ba9c2cd2f2c8751d9